### PR TITLE
Include otp_time_drift field in database migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ Gemfile.lock
 
 # Generated test files
 tmp/*
+test/tmp/*

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -9,6 +9,7 @@ class DeviseOtpAddTo<%= table_name.camelize %> < ActiveRecord::Migration
       t.integer   :otp_failed_attempts,  :default => 0, :null => false
       t.integer   :otp_recovery_counter, :default => 0, :null => false
       t.string    :otp_persistence_seed
+      t.integer   :otp_time_drift,        :default => 0, :null => false
 
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
@@ -16,7 +17,7 @@ class DeviseOtpAddTo<%= table_name.camelize %> < ActiveRecord::Migration
     add_index :<%= table_name %>, :otp_session_challenge,  :unique => true
     add_index :<%= table_name %>, :otp_challenge_expires
   end
-  
+
   def self.down
     change_table :<%= table_name %> do |t|
       t.remove :otp_auth_secret, :otp_recovery_secret, :otp_enabled, :otp_mandatory, :otp_enabled_on, :otp_session_challenge,

--- a/test/generators/active_record_generator_test.rb
+++ b/test/generators/active_record_generator_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+require "rails/generators/test_case"
+
+if DEVISE_ORM == :active_record
+  require "generators/active_record/devise_otp_generator"
+
+  class ActiveRecordGeneratorTest < Rails::Generators::TestCase
+    tests ActiveRecord::Generators::DeviseOtpGenerator
+    destination File.expand_path("../../tmp", __FILE__)
+    setup :prepare_destination
+
+    test "use integer column type for otp_time_drift" do
+      run_generator %w(user)
+      assert_migration "db/migrate/devise_otp_add_to_users.rb", /t.integer   :otp_time_drift/
+    end
+  end
+end


### PR DESCRIPTION
The library relies on this field when resetting otp credentials and disabling otp, but the generated migration was missing the field.
