### PR TITLE
When enabling OTP, reset if auth secret is missing

### DIFF
--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -61,6 +61,10 @@ module Devise::Models
     end
 
     def enable_otp!
+      if otp_persistence_seed.nil?
+        reset_otp_credentials!
+      end
+
       update_attributes!(:otp_enabled => true, :otp_enabled_on => Time.now)
     end
 


### PR DESCRIPTION
Stupid scenario, but it caught me out almost immediately:
* Create an 'admin' user using Rails console: User.create!(:email=>'bob@xyz.com', :password=>'monkeys')
* Attempt to set up OTP access for the 'admin' user

The OTP seed is only set during validation, which doesn't appear to happen when created via the console, so this is a simple fix to ensure that nothing strange has happened.

My next patch will be to add an OTP validation stage, where the user has to enter a valid OTP before OTP is actually enabled. I also think that the user backup codes should be quite obvious and visible for the user ie. no action required for them to copy them out.