### PR TITLE
Require gem assets. Closes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Don't forget to migrate:
 
     rake db:migrate
 
+Add the gem's javascript to you application.js
+
+    //= require devise-otp
+
+
+
 ### Custom Views
 
 If you want to customise your views (which you likely will want to), you can use the generator:

--- a/app/assets/javascripts/devise-otp.js
+++ b/app/assets/javascripts/devise-otp.js
@@ -1,0 +1,1 @@
+//= require_tree .


### PR DESCRIPTION
- Adds devise-otp.js file and documentation to require it. This resolves and issue where the qrcode library was not auto loaded.