### PR TITLE
Proper token issuer setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The install generator adds some options to the end of your Devise config file (c
 * `config.otp_credentials_refresh` - Users that have logged in longer than this time ago, are going to be asked their password (and an OTP challenge, if enabled) before they can see or change their otp informations. (defaults to `15.minutes`)
 * `config.otp_recovery_tokens` - Whether the users are given a list of one-time recovery tokens, for emergency access (default: `10`, set to `false` to disable)
 * `config.otp_trust_persistence` - The user is allowed to set his browser as "trusted", no more OTP challenges will be asked for that browser, for a limited time. (default: `1.month`, set to false to disable setting the browser as trusted)
-* `config.otp_uri_application` - The name of this application, to be added to the provisioning url as '<user_email>/application_name' (defaults to the Rails application class)
+* `config.otp_issuer` - The name of the token issuer, to be added to the provisioning url. Display will vary based on token application. (defaults to the Rails application class)
 
 ## Todo
 

--- a/lib/devise-otp.rb
+++ b/lib/devise-otp.rb
@@ -53,10 +53,10 @@ module Devise
   @@otp_credentials_refresh = 15.minutes  # or like 15.minutes, false to disable
 
   #
-  # the user identifier for the token is <email>/Application_name
+  # the name of the token issuer
   #
-  mattr_accessor :otp_uri_application
-  @@otp_uri_application = Rails.application.class.parent_name
+  mattr_accessor :otp_issuer
+  @@otp_issuer = Rails.application.class.parent_name
 
   module Otp
 

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -12,7 +12,7 @@ module Devise::Models
 
     module ClassMethods
       ::Devise::Models.config(self, :otp_authentication_timeout, :otp_drift_window, :otp_trust_persistence,
-                                    :otp_mandatory, :otp_credentials_refresh, :otp_uri_application, :otp_recovery_tokens)
+                                    :otp_mandatory, :otp_credentials_refresh, :otp_issuer, :otp_recovery_tokens)
 
       def find_valid_otp_challenge(challenge)
         with_valid_otp_challenge(Time.now).where(:otp_session_challenge => challenge).first
@@ -20,7 +20,7 @@ module Devise::Models
     end
 
     def time_based_otp
-      @time_based_otp ||= ROTP::TOTP.new(otp_auth_secret)
+      @time_based_otp ||= ROTP::TOTP.new(otp_auth_secret, issuer: "#{self.class.otp_issuer || Rails.application.class.parent_name}")
     end
 
     def recovery_otp
@@ -32,7 +32,7 @@ module Devise::Models
     end
 
     def otp_provisioning_identifier
-      "#{email}/#{self.class.otp_uri_application || Rails.application.class.parent_name}"
+      email
     end
 
 

--- a/lib/generators/devise_otp/install_generator.rb
+++ b/lib/generators/devise_otp/install_generator.rb
@@ -36,9 +36,9 @@ content = <<-CONTENT
   # set to false to disable setting the browser as trusted
   #config.otp_trust_persistence = 1.month
 
-  # The name of this application, to be added to the provisioning
-  # url as '<user_email>/application_name' (defaults to the Rails application class)
-  #config.otp_uri_application = 'my_application'
+  # The name of the token issuer, to be added to the provisioning
+  # url. Display will vary based on token application. (defaults to the Rails application class)
+  #config.otp_issuer = 'my_application'
 
 CONTENT
 


### PR DESCRIPTION
- This removes the application name from what should only be the account identifier and moves it to the proper location of issuer.
- The issuer will display in select applications. Google Authenticator places the issuer name above the token. Example:
![img_0148](https://cloud.githubusercontent.com/assets/945202/8845311/7efc78f2-30e3-11e5-9f75-2f4933636a1c.PNG)
