### PR TITLE
Allow current recovery codes to be downloaded.

### DIFF
--- a/app/controllers/devise_otp/tokens_controller.rb
+++ b/app/controllers/devise_otp/tokens_controller.rb
@@ -82,7 +82,13 @@ class DeviseOtp::TokensController < DeviseController
   #
   #
   def recovery
-    render :recovery
+    respond_to do |format|
+      format.html
+      format.js
+      format.text do
+        send_data render_to_string(template: "devise_otp/tokens/recovery_codes.text.erb"), filename: "recovery-codes.txt"
+      end
+    end
   end
 
 

--- a/app/views/devise_otp/tokens/recovery_codes.text.erb
+++ b/app/views/devise_otp/tokens/recovery_codes.text.erb
@@ -1,0 +1,3 @@
+<% resource.next_otp_recovery_tokens.each do |seq, code| %>
+<%= code %>
+<% end %>


### PR DESCRIPTION
- this allows the `format: :text` to be added to the `recovery_otp_token_for` url so that the recover codes can be downloaded in a text file.