### PR TITLE
Remove the requirement for TOTP token on credential refresh.

### DIFF
--- a/app/controllers/devise_otp/credentials_controller.rb
+++ b/app/controllers/devise_otp/credentials_controller.rb
@@ -70,19 +70,10 @@ class DeviseOtp::CredentialsController < DeviseController
   # lets the user through is the refresh is valid
   #
   def set_refresh
-
     ensure_resource!
     # I am sure there's a much better way
     if resource.valid_password?(params[resource_name][:refresh_password])
-      if resource.otp_enabled?
-        if resource.validate_otp_token(params[resource_name][:token])
-          done_valid_refresh
-        else
-          failed_refresh
-        end
-      else
-        done_valid_refresh
-      end
+      done_valid_refresh
     else
       failed_refresh
     end

--- a/app/views/devise_otp/credentials/refresh.html.erb
+++ b/app/views/devise_otp/credentials/refresh.html.erb
@@ -11,10 +11,5 @@
     <div><%= f.label :password %><br />
 	<%= f.password_field :refresh_password, :autocomplete => :off, :autofocus => true %></div>
 
-  <%- if resource.otp_enabled? %>
-    <div><%= f.label :token, I18n.t(:token, {:scope => 'devise.otp.credentials_refresh'}) %></p><br />
-    <%= f.password_field :token, :autocomplete => :off%></div>
-  <% end %>
-
 	<div><%= f.submit I18n.t(:go_on, {:scope => 'devise.otp.credentials_refresh'}) %></div>
 <% end %>


### PR DESCRIPTION
This simply removes the necessity for the user to provide their TOTP token when refreshing credentials. 

Reference #24 
