### PR TITLE
add tag(/div) to otp_authenticator_token_image_js in helpers file

### DIFF
--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -152,7 +152,7 @@ module DeviseOtpAuthenticatable
               colorLight : "#ffffff",
               correctLevel : QRCode.CorrectLevel.H
             });
-          ])
+          ]) + tag("/div")
         end
       end
 


### PR DESCRIPTION
The tag at the beginning of the function just leaves an open div, which breaks some of the html on the page. This is a minor fix to stop that from happening