### PR TITLE
trusted device checkbox on otp login page

### DIFF
--- a/app/controllers/devise_otp/credentials_controller.rb
+++ b/app/controllers/devise_otp/credentials_controller.rb
@@ -49,6 +49,7 @@ class DeviseOtp::CredentialsController < DeviseController
         sign_in(resource_name, resource)
 
         otp_refresh_credentials_for(resource)
+        otp_set_trusted_device_for(resource) if trusted_devices_enabled? && params[resource_name][:trust_device] == "1"
         respond_with resource, :location => after_sign_in_path_for(resource)
       else
         otp_set_flash_message :alert, :token_invalid

--- a/app/views/devise_otp/credentials/show.html.erb
+++ b/app/views/devise_otp/credentials/show.html.erb
@@ -16,6 +16,12 @@
         <%= f.text_field :token, :autocomplete => :off, :autofocus => true, :size => 6, :value => '' %>
     </p>
 
+  <%- if !@recovery && trusted_devices_enabled? %>
+    <p><%= f.label :trust_device, I18n.t('trust_device', {:scope => 'devise.otp.submit_token'}) %>
+        <%= f.check_box :trust_device, :autocomplete => :off, :checked => false %>
+    </p>
+  <% end %>
+
 	<p><%= f.submit I18n.t('submit', {:scope => 'devise.otp.submit_token'}) %></p>
     <%- if !@recovery && recovery_enabled? %>
       <p><%= link_to I18n.t('recovery_link', {:scope => 'devise.otp.submit_token'}), otp_credential_path_for(resource_name, :challenge => @challenge, :recovery => true) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
         recovery_prompt: 'Please enter your recovery code:'
         submit: 'Submit Token'
         recovery_link: "I don't have my device, I want to use a recovery code"
+        trust_device: "Trust this device"
 
       credentials:
         token_invalid: 'The token you provided was invalid.'

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -28,7 +28,7 @@ module DeviseOtpAuthenticatable
 
 
       def trusted_devices_enabled?
-        resource.class.otp_trust_persistence && (resource.class.otp_trust_persistence > 0)
+        resource_class.otp_trust_persistence && (resource_class.otp_trust_persistence > 0)
       end
 
       def recovery_enabled?


### PR DESCRIPTION
This pull request adds support for a checkbox on the "Check Token" for a adding a trusted browser.
![feature](https://cloud.githubusercontent.com/assets/641859/13442348/60ccbc42-dfc1-11e5-9eb9-ad4de34d5bf7.png)
