### PR TITLE
mandatory otp fix

### DIFF
--- a/lib/devise_otp_authenticatable/hooks/sessions.rb
+++ b/lib/devise_otp_authenticatable/hooks/sessions.rb
@@ -25,7 +25,7 @@ module DeviseOtpAuthenticatable::Hooks
         store_location_for(resource, devise_stored_location) # restore the stored location
         respond_with resource, location: otp_credential_path_for(resource, {challenge: challenge})
       elsif otp_mandatory_on?(resource) # if mandatory, log in user but send him to the must activate otp
-        set_flash_message(:notice, :signed_in_but_otp) if is_navigational_format?
+        #set_flash_message(:notice, :signed_in_but_otp) if is_navigational_format?
         sign_in(resource_name, resource)
         respond_with resource, location: otp_token_path_for(resource)
       else
@@ -49,9 +49,8 @@ module DeviseOtpAuthenticatable::Hooks
     # the resource -should- have otp turned on, but it isn't
     #
     def otp_mandatory_on?(resource)
-      return true if resource.class.otp_mandatory
+      return true if resource.class.otp_mandatory && !resource.otp_enabled
       return false unless resource.respond_to?(:otp_mandatory)
-
       resource.otp_mandatory && !resource.otp_enabled
     end
   end

--- a/lib/devise_otp_authenticatable/hooks/sessions.rb
+++ b/lib/devise_otp_authenticatable/hooks/sessions.rb
@@ -25,7 +25,7 @@ module DeviseOtpAuthenticatable::Hooks
         store_location_for(resource, devise_stored_location) # restore the stored location
         respond_with resource, location: otp_credential_path_for(resource, {challenge: challenge})
       elsif otp_mandatory_on?(resource) # if mandatory, log in user but send him to the must activate otp
-        #set_flash_message(:notice, :signed_in_but_otp) if is_navigational_format?
+        set_flash_message(:notice, :signed_in_but_otp) if is_navigational_format?
         sign_in(resource_name, resource)
         respond_with resource, location: otp_token_path_for(resource)
       else
@@ -51,6 +51,7 @@ module DeviseOtpAuthenticatable::Hooks
     def otp_mandatory_on?(resource)
       return true if resource.class.otp_mandatory && !resource.otp_enabled
       return false unless resource.respond_to?(:otp_mandatory)
+
       resource.otp_mandatory && !resource.otp_enabled
     end
   end


### PR DESCRIPTION
If you have config.otp_mandatory enabled, a user is prompted to enable otp on every login even if they already have it enabled.