### PR TITLE
Unblock Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ lib/bundler/man
 test/dummy/log/**
 test/dummy/tmp/**
 test/dummy/db/*.sqlite3
+test/dummy/db/*.sqlite3-shm
+test/dummy/db/*.sqlite3-wal
 
 Gemfile.lock
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -53,8 +53,6 @@ module Dummy
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    config.active_record.legacy_connection_handling = false
-
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require "capybara/rails"
 require "capybara/cuprite"
 require "minitest/reporters"
 
-MiniTest::Reporters.use!
+Minitest::Reporters.use!
 
 # I18n.load_path << File.expand_path("../support/locale/en.yml", __FILE__) if DEVISE_ORM == :mongoid
 


### PR DESCRIPTION
This pull request resolves the issues below to allow running of tests again:

- The constant name for minitest-reporters is now Minitest::Reporters (as of version 1.6.1).
- legacy_connection_handling was deprecated in Rails 7.0 and removed in Rails 7.1
- SQLite generates wal and shm files by default in the latest version.

References:
- https://github.com/minitest-reporters/minitest-reporters/blob/master/CHANGELOG.md