### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       matrix:
         ruby:
           - '3.1'
-          - '3.0'
-          - '2.7'
 
     steps:
       - name: Checkout

--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rdoc"
   gem.add_development_dependency "shoulda"
   gem.add_development_dependency "sprockets-rails"
-  gem.add_development_dependency "sqlite3"
+  gem.add_development_dependency "sqlite3", "~> 1.4"
   gem.add_development_dependency "standardrb"
 end


### PR DESCRIPTION
Try pinning sqlite3 to "~> 1.4" for CI tests (needed for ActiveRecord adapter for now).

cf. https://github.com/rails/rails/pull/51592