### PR TITLE
Update otp_credentials#show to redirect to new_session_path for blank challenge

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -14,11 +14,11 @@ module DeviseOtp
         @recovery = (params[:recovery] == "true") && recovery_enabled?
 
         if @challenge.nil?
-          redirect_to :root
+          redirect_to new_session_path(resource_name)
         else
           self.resource = resource_class.find_valid_otp_challenge(@challenge)
           if resource.nil?
-            redirect_to :root
+            redirect_to new_session_path(resource_name)
           elsif @recovery
             @recovery_count = resource.otp_recovery_counter
             render :show


### PR DESCRIPTION
The otp_credentials#show action returns an "undefined method root_url" error for blank challenge or resource (which is acquired via the challenge), as there is no root path defined in the routes. It is probably better to redirect these requests to new_session_path anyway, though, as the update action does.

This PR makes this change and resolves the issue.