### PR TITLE
Simplify refresh_credential functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## UNRELEASED
 
+Summary: Update the needs_credentials_refresh? method to take utilize current_sign_in_at when available
+
+Details:
+- Update needs_credentials_refresh? method to reference current_sign_in_at when present;
+- Break apart needs_credential_refresh? method, and set return URL within otp_tokens controller for simplicity;
+- Remove 'refresh_otp_credentials_for(resource)' from create_otp_session method (no longer needed);
+
+## UNRELEASED
+
 Summary:
 - Require confirmation token before enabling Two Factor Authentication (2FA) to ensure that user has added OTP token properly to their device
 - Update system to populate OTP secrets as needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## UNRELEASED
 
-Summary: Update the needs_credentials_refresh? method to take utilize current_sign_in_at when available
+Use dedicated devise hook for refreshing credentials.
 
 Details:
-- Update needs_credentials_refresh? method to reference current_sign_in_at when present;
-- Break apart needs_credential_refresh? method, and set return URL within otp_tokens controller for simplicity;
-- Remove 'refresh_otp_credentials_for(resource)' from create_otp_session method (no longer needed);
+- Add dedicated hook and column for refresh_credential functionality;
+- Move/simplify check/redirection to refresh_credentials! helper method;
+- Remove "refresh_otp_credentials" method from session hook (no longer needed);
+- Remove comments regarding cookie/persistence scope (no longer needed);
+
+Breaking Changes:
+- Requires adding the credentials_refreshed_at field to the database;
 
 ## UNRELEASED
 

--- a/app/controllers/devise_otp/devise/otp_tokens_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_tokens_controller.rb
@@ -101,6 +101,7 @@ module DeviseOtp
         ensure_resource!
 
         if needs_credentials_refresh?(resource)
+          otp_set_refresh_return_url
           otp_set_flash_message :notice, :need_to_refresh_credentials
           redirect_to refresh_otp_credential_path_for(resource)
         end

--- a/app/controllers/devise_otp/devise/otp_tokens_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_tokens_controller.rb
@@ -3,7 +3,7 @@ module DeviseOtp
     class OtpTokensController < DeviseController
       include ::Devise::Controllers::Helpers
 
-      prepend_before_action :ensure_credentials_refresh
+      prepend_before_action :refresh_credentials!
       prepend_before_action :authenticate_scope!
 
       protect_from_forgery except: [:clear_persistence, :delete_persistence]
@@ -96,16 +96,6 @@ module DeviseOtp
       end
 
       private
-
-      def ensure_credentials_refresh
-        ensure_resource!
-
-        if needs_credentials_refresh?(resource)
-          otp_set_refresh_return_url
-          otp_set_flash_message :notice, :need_to_refresh_credentials
-          redirect_to refresh_otp_credential_path_for(resource)
-        end
-      end
 
       def scope
         resource_name.to_sym

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -39,8 +39,19 @@ module DeviseOtpAuthenticatable
         end
       end
 
-      # fixme do cookies and persistence need to be scoped? probably
+      # check if the resource needs a credentials refresh, and redirect if needed
+      # this resource.
       #
+      def refresh_credentials!
+        ensure_resource!
+
+        if needs_credentials_refresh?(resource)
+          otp_set_refresh_return_url
+          otp_set_flash_message :notice, :need_to_refresh_credentials
+          redirect_to refresh_otp_credential_path_for(resource)
+        end
+      end
+
       # check if the resource needs a credentials refresh. IE, they need to be asked a password again to access
       # this resource.
       #

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -47,8 +47,19 @@ module DeviseOtpAuthenticatable
       def needs_credentials_refresh?(resource)
         return false unless resource.class.otp_credentials_refresh
 
-        (!session[otp_scoped_refresh_property].present? ||
-            (session[otp_scoped_refresh_property] < DateTime.now)).tap { |need| otp_set_refresh_return_url if need }
+        current_sign_in_stale? and (refreshed_sign_in_blank? or refreshed_sign_in_stale?)
+      end
+
+      def current_sign_in_stale?
+        resource.current_sign_in_at + resource.class.otp_credentials_refresh < DateTime.now
+      end
+
+      def refreshed_sign_in_blank?
+        session[otp_scoped_refresh_property].blank?
+      end
+
+      def refreshed_sign_in_stale?
+        session[otp_scoped_refresh_property] < DateTime.now
       end
 
       #

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -45,21 +45,9 @@ module DeviseOtpAuthenticatable
       # this resource.
       #
       def needs_credentials_refresh?(resource)
-        return false unless resource.class.otp_credentials_refresh
+        return false unless resource.class.otp_credentials_refresh and resource.respond_to?(:credentials_refreshed_at)
 
-        current_sign_in_stale? and (refreshed_sign_in_blank? or refreshed_sign_in_stale?)
-      end
-
-      def current_sign_in_stale?
-        resource.current_sign_in_at + resource.class.otp_credentials_refresh < DateTime.now
-      end
-
-      def refreshed_sign_in_blank?
-        session[otp_scoped_refresh_property].blank?
-      end
-
-      def refreshed_sign_in_stale?
-        session[otp_scoped_refresh_property] < DateTime.now
+        resource.credentials_refreshed_at.blank? or resource.credentials_refreshed_at + resource.class.otp_credentials_refresh < DateTime.now
       end
 
       #
@@ -67,7 +55,7 @@ module DeviseOtpAuthenticatable
       #
       def otp_refresh_credentials_for(resource)
         return false unless resource.class.otp_credentials_refresh
-        session[otp_scoped_refresh_property] = (Time.now + resource.class.otp_credentials_refresh)
+        resource.update(:credentials_refreshed_at => DateTime.now)
       end
 
       #

--- a/lib/devise_otp_authenticatable/hooks/refreshable.rb
+++ b/lib/devise_otp_authenticatable/hooks/refreshable.rb
@@ -1,0 +1,7 @@
+# After each sign in, update credentials refreshed at time
+Warden::Manager.after_set_user except: :fetch do |record, warden, options|
+  if record.class.otp_credentials_refresh && record.respond_to?(:credentials_refreshed_at) && warden.authenticated?(options[:scope])
+    record.update(:credentials_refreshed_at => DateTime.now)
+  end
+end
+

--- a/lib/devise_otp_authenticatable/hooks/sessions.rb
+++ b/lib/devise_otp_authenticatable/hooks/sessions.rb
@@ -16,8 +16,6 @@ module DeviseOtpAuthenticatable::Hooks
       devise_stored_location = stored_location_for(resource) # Grab the current stored location before it gets lost by warden.logout
       store_location_for(resource, devise_stored_location) # Restore it since #stored_location_for removes it
 
-      otp_refresh_credentials_for(resource)
-
       yield resource if block_given?
       if otp_challenge_required_on?(resource)
         challenge = resource.generate_otp_challenge!

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -1,4 +1,5 @@
 require "rotp"
+require 'devise_otp_authenticatable/hooks/refreshable'
 
 module Devise::Models
   module OtpAuthenticatable

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -12,6 +12,8 @@ class DeviseOtpAddTo<%= table_name.camelize %> < ActiveRecord::Migration
 
       t.string    :otp_session_challenge
       t.datetime  :otp_challenge_expires
+
+      t.datetime  :credentials_refreshed_at
     end
     add_index :<%= table_name %>, :otp_session_challenge,  :unique => true
     add_index :<%= table_name %>, :otp_challenge_expires

--- a/test/dummy/db/migrate/20130131160351_devise_otp_add_to_users.rb
+++ b/test/dummy/db/migrate/20130131160351_devise_otp_add_to_users.rb
@@ -13,6 +13,8 @@ class DeviseOtpAddToUsers < ActiveRecord::Migration[5.0]
 
       t.string :otp_session_challenge
       t.datetime :otp_challenge_expires
+
+      t.datetime :credentials_refreshed_at
     end
 
     add_index :users, :otp_session_challenge, unique: true


### PR DESCRIPTION
@strzibny, I am requesting to simplify the refresh_credential functionality in preparation for some other Pull Requests.

This Pull request updates the needs_credentials_refresh? method to consider the current_sign_in_at so that we don't have to call "refresh_otp_credentials_for(resource)" artificially when signing in.

Details:
- Update needs_credentials_refresh? method to reference current_sign_in_at when present;
- Break apart needs_credential_refresh? method, and set return URL within otp_tokens controller for simplicity;
- Remove 'refresh_otp_credentials_for(resource)' from create_otp_session method (no longer needed);

Current tests are sufficient and passing for this change.