### PR TITLE
Fix Mandatory OTP Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## UNRELEASED
 
+Summary: Move mandatory OTP functionality to the helper layer to ensure that it is enforced throughout application (rather than one time at log in).
+
+Details:
+- Add PublicHelpers class, and add to Devise @@helpers variable to generate per-scope ensure\_mandatory\_{scope}\_otp! methods;
+- Update order of module definitions and "require" statements in devise-otp.rb (required for adding DeviseOtpAuthenticable PublicHelpers to Devise @@helpers variable);
+
+Breaking Changes:
+- Requires adding "ensure\_mandatory\_{scope}\_otp! to controllers;
+
+## UNRELEASED
+
 Summary:
 - Require confirmation token before enabling Two Factor Authentication (2FA) to ensure that user has added OTP token properly to their device
 - Update system to populate OTP secrets as needed

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The install generator adds some options to the end of your Devise config file (`
 ## Mandatory OTP
 Enforcing mandatory OTP requires adding the ensure\_mandatory\_{scope}\_otp! method to the desired controller(s) to ensure that the user is redirected to the Enable Two-Factor Authentication form before proceeding to other parts of the application. This functions the same way as the authenticate\_{scope}! methods, and can be included inline with them in the controllers, e.g.:
 
-    authenticate_user!
-    ensure_mandatory_user_otp!
+    before_action :authenticate_user!
+    before_action :ensure_mandatory_user_otp!
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The install generator adds some options to the end of your Devise config file (`
 * `config.otp_issuer`: The name of the token issuer, to be added to the provisioning url. Display will vary based on token application. (defaults to the Rails application class)
 * `config.otp_controller_path`: The view path for Devise OTP controllers. The default being 'devise' to match Devise default installation.
 
+## Mandatory OTP
+Enforcing mandatory OTP requires adding the ensure\_mandatory\_{scope}\_otp! method to the desired controller(s) to ensure that the user is redirected to the Enable Two-Factor Authentication form before proceeding to other parts of the application. This functions the same way as the authenticate\_{scope}! methods, and can be included inline with them in the controllers, e.g.:
+
+    authenticate_user!
+    ensure_mandatory_user_otp!
+
 ## Authors
 
 The project was originally started by Lele Forzani by forking [devise_google_authenticator](https://github.com/AsteriskLabs/devise_google_authenticator) and still contains some devise_google_authenticator code. It's now maintained by [Josef Strzibny](https://github.com/strzibny/).

--- a/lib/devise-otp.rb
+++ b/lib/devise-otp.rb
@@ -59,7 +59,16 @@ module DeviseOtpAuthenticatable
   module Controllers
     autoload :Helpers, "devise_otp_authenticatable/controllers/helpers"
     autoload :UrlHelpers, "devise_otp_authenticatable/controllers/url_helpers"
+    autoload :PublicHelpers, "devise_otp_authenticatable/controllers/public_helpers"
   end
+end
+
+ActiveSupport.on_load(:action_controller) do
+  Devise.mappings.each do |key, mapping|
+    DeviseOtpAuthenticatable::Controllers::PublicHelpers.define_helpers(mapping)
+  end
+
+  include DeviseOtpAuthenticatable::Controllers::PublicHelpers
 end
 
 require "devise_otp_authenticatable/routes"

--- a/lib/devise-otp.rb
+++ b/lib/devise-otp.rb
@@ -51,6 +51,22 @@ module Devise
 
   module Otp
   end
+
+  # Regenerates url helpers considering Devise.mapping
+  def self.regenerate_helpers!
+    Devise::Controllers::UrlHelpers.remove_helpers!
+    Devise::Controllers::UrlHelpers.generate_helpers!
+
+    ActiveSupport.on_load(:action_controller) do
+      Devise.mappings.each do |key, mapping|
+        DeviseOtpAuthenticatable::Controllers::PublicHelpers.define_helpers(mapping)
+      end
+
+      include DeviseOtpAuthenticatable::Controllers::PublicHelpers
+    end
+
+  end
+
 end
 
 module DeviseOtpAuthenticatable
@@ -61,14 +77,6 @@ module DeviseOtpAuthenticatable
     autoload :UrlHelpers, "devise_otp_authenticatable/controllers/url_helpers"
     autoload :PublicHelpers, "devise_otp_authenticatable/controllers/public_helpers"
   end
-end
-
-ActiveSupport.on_load(:action_controller) do
-  Devise.mappings.each do |key, mapping|
-    DeviseOtpAuthenticatable::Controllers::PublicHelpers.define_helpers(mapping)
-  end
-
-  include DeviseOtpAuthenticatable::Controllers::PublicHelpers
 end
 
 require "devise_otp_authenticatable/routes"

--- a/lib/devise-otp.rb
+++ b/lib/devise-otp.rb
@@ -52,19 +52,19 @@ module Devise
   module Otp
   end
 
-  # Regenerates url helpers considering Devise.mapping
+  #
+  # tapping into regenerate_helpers! method, to ensure that Devise mappings are present when generating public helpers
+  #
   def self.regenerate_helpers!
+    # Existing (Devise)
     Devise::Controllers::UrlHelpers.remove_helpers!
     Devise::Controllers::UrlHelpers.generate_helpers!
 
+    # Additions (Devise OTP)
+    DeviseOtpAuthenticatable::Controllers::PublicHelpers.generate_helpers!
     ActiveSupport.on_load(:action_controller) do
-      Devise.mappings.each do |key, mapping|
-        DeviseOtpAuthenticatable::Controllers::PublicHelpers.define_helpers(mapping)
-      end
-
       include DeviseOtpAuthenticatable::Controllers::PublicHelpers
     end
-
   end
 
 end

--- a/lib/devise-otp.rb
+++ b/lib/devise-otp.rb
@@ -9,6 +9,9 @@ require "active_support/concern"
 
 require "devise"
 
+#
+# define DeviseOtpAuthenticatable module, and autoload hooks and helpers
+#
 module DeviseOtpAuthenticatable
   autoload :Hooks, "devise_otp_authenticatable/hooks"
 
@@ -22,6 +25,9 @@ end
 require "devise_otp_authenticatable/routes"
 require "devise_otp_authenticatable/engine"
 
+#
+# update Devise module with additions needed for DeviseOtpAuthenticatable
+#
 module Devise
   mattr_accessor :otp_mandatory
   @@otp_mandatory = false
@@ -63,7 +69,8 @@ module Devise
   @@otp_controller_path = "devise"
 
   #
-  # add PublicHelpers to helpers class variable to ensure that "define_helpers" is run when adding mapping in Devise gem (lib/devise.rb#541)
+  # add PublicHelpers to helpers class variable to ensure that per-mapping helpers are present.
+  # this integrates with the "define_helpers," which is run when adding each mapping in the Devise gem (lib/devise.rb#541)
   #
   @@helpers << DeviseOtpAuthenticatable::Controllers::PublicHelpers
 
@@ -75,7 +82,9 @@ end
 Devise.add_module :otp_authenticatable,
   controller: :tokens,
   model: "devise_otp_authenticatable/models/otp_authenticatable", route: :otp
-
+#
+# add PublicHelpers after adding Devise module to ensure that per-mapping routes from above are included
+#
 ActiveSupport.on_load(:action_controller) do
   include DeviseOtpAuthenticatable::Controllers::PublicHelpers
 end

--- a/lib/devise_otp_authenticatable/controllers/public_helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/public_helpers.rb
@@ -24,6 +24,10 @@ module DeviseOtpAuthenticatable
         end
       end
 
+      def test_method
+        raise "Test method included successfully."
+      end
+
       def otp_mandatory_on?(resource)
         return true if resource.class.otp_mandatory && !resource.otp_enabled
         return false unless resource.respond_to?(:otp_mandatory)

--- a/lib/devise_otp_authenticatable/controllers/public_helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/public_helpers.rb
@@ -22,12 +22,6 @@ module DeviseOtpAuthenticatable
             end
           end
         METHODS
-
-        ActiveSupport.on_load(:action_controller) do
-          if respond_to?(:helper_method)
-            helper_method "ensure_mandatory_#{mapping}_otp!"
-          end
-        end
       end
 
       def test_method

--- a/lib/devise_otp_authenticatable/controllers/public_helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/public_helpers.rb
@@ -6,12 +6,6 @@ module DeviseOtpAuthenticatable
       def self.define_helpers(mapping) #:nodoc:
         mapping = mapping.name
 
-        class_eval <<-TEST_METHOD, __FILE__, __LINE__ + 1
-          def test_#{mapping}_method
-            raise "Test method for #{mapping} included successfully."
-          end
-        TEST_METHOD
-
         class_eval <<-METHODS, __FILE__, __LINE__ + 1
           def ensure_mandatory_#{mapping}_otp!
             resource = current_#{mapping}
@@ -22,10 +16,6 @@ module DeviseOtpAuthenticatable
             end
           end
         METHODS
-      end
-
-      def test_method
-        raise "Test method included successfully."
       end
 
       def otp_mandatory_on?(resource)

--- a/lib/devise_otp_authenticatable/controllers/public_helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/public_helpers.rb
@@ -3,6 +3,12 @@ module DeviseOtpAuthenticatable
     module PublicHelpers
       extend ActiveSupport::Concern
 
+      def self.generate_helpers!
+        Devise.mappings.each do |key, mapping|
+          self.define_helpers(mapping)
+        end
+      end
+
       def self.define_helpers(mapping) #:nodoc:
         mapping = mapping.name
 

--- a/lib/devise_otp_authenticatable/controllers/public_helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/public_helpers.rb
@@ -1,0 +1,36 @@
+module DeviseOtpAuthenticatable
+  module Controllers
+    module PublicHelpers
+      extend ActiveSupport::Concern
+
+      def self.define_helpers(mapping) #:nodoc:
+        mapping = mapping.name
+
+        class_eval <<-METHODS, __FILE__, __LINE__ + 1
+          def ensure_mandatory_#{mapping}_otp!
+            resource = current_#{mapping}
+            if !devise_controller?
+              if otp_mandatory_on?(resource)
+                redirect_to edit_#{mapping}_otp_token_path
+              end
+            end
+          end
+        METHODS
+
+        ActiveSupport.on_load(:action_controller) do
+          if respond_to?(:helper_method)
+            helper_method "ensure_mandatory_#{mapping}_otp!"
+          end
+        end
+      end
+
+      def otp_mandatory_on?(resource)
+        return true if resource.class.otp_mandatory && !resource.otp_enabled
+        return false unless resource.respond_to?(:otp_mandatory)
+
+        resource.otp_mandatory && !resource.otp_enabled
+      end
+
+    end
+  end
+end

--- a/lib/devise_otp_authenticatable/controllers/public_helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/public_helpers.rb
@@ -6,6 +6,12 @@ module DeviseOtpAuthenticatable
       def self.define_helpers(mapping) #:nodoc:
         mapping = mapping.name
 
+        class_eval <<-TEST_METHOD, __FILE__, __LINE__ + 1
+          def test_#{mapping}_method
+            raise "Test method for #{mapping} included successfully."
+          end
+        TEST_METHOD
+
         class_eval <<-METHODS, __FILE__, __LINE__ + 1
           def ensure_mandatory_#{mapping}_otp!
             resource = current_#{mapping}

--- a/lib/devise_otp_authenticatable/engine.rb
+++ b/lib/devise_otp_authenticatable/engine.rb
@@ -12,7 +12,6 @@ module DeviseOtpAuthenticatable
       ActiveSupport.on_load(:devise_controller) do
         include DeviseOtpAuthenticatable::Controllers::UrlHelpers
         include DeviseOtpAuthenticatable::Controllers::Helpers
-        include DeviseOtpAuthenticatable::Controllers::PublicHelpers
       end
 
       ActiveSupport.on_load(:action_view) do

--- a/lib/devise_otp_authenticatable/engine.rb
+++ b/lib/devise_otp_authenticatable/engine.rb
@@ -12,6 +12,7 @@ module DeviseOtpAuthenticatable
       ActiveSupport.on_load(:devise_controller) do
         include DeviseOtpAuthenticatable::Controllers::UrlHelpers
         include DeviseOtpAuthenticatable::Controllers::Helpers
+        include DeviseOtpAuthenticatable::Controllers::PublicHelpers
       end
 
       ActiveSupport.on_load(:action_view) do

--- a/lib/devise_otp_authenticatable/hooks/sessions.rb
+++ b/lib/devise_otp_authenticatable/hooks/sessions.rb
@@ -24,10 +24,6 @@ module DeviseOtpAuthenticatable::Hooks
         warden.logout
         store_location_for(resource, devise_stored_location) # restore the stored location
         respond_with resource, location: otp_credential_path_for(resource, {challenge: challenge})
-      elsif otp_mandatory_on?(resource) # if mandatory, log in user but send him to the must activate otp
-        set_flash_message(:notice, :signed_in_but_otp) if is_navigational_format?
-        sign_in(resource_name, resource)
-        respond_with resource, location: otp_token_path_for(resource)
       else
         sign_in(resource_name, resource)
         respond_with resource, location: after_sign_in_path_for(resource)
@@ -45,14 +41,5 @@ module DeviseOtpAuthenticatable::Hooks
       resource.otp_enabled && !is_otp_trusted_browser_for?(resource)
     end
 
-    #
-    # the resource -should- have otp turned on, but it isn't
-    #
-    def otp_mandatory_on?(resource)
-      return true if resource.class.otp_mandatory && !resource.otp_enabled
-      return false unless resource.respond_to?(:otp_mandatory)
-
-      resource.otp_mandatory && !resource.otp_enabled
-    end
   end
 end


### PR DESCRIPTION
@strzibny, here is the completed mandatory_otp solution. It resolves the main issue where mandatory otp can be skipped in Issue #71. Please let me know your thoughts!

(Excerpted from CHANGELOG)
Summary: Move mandatory OTP functionality to the helper layer to ensure that it is enforced throughout application (rather than one time at log in).

Details:
- Add PublicHelpers class, and add to Devise @@helpers variable to generate per-scope ensure\_mandatory\_{scope}\_otp! methods;
- Update order of module definitions and "require" statements in devise-otp.rb (required for adding DeviseOtpAuthenticable PublicHelpers to Devise @@helpers variable);

Breaking Changes:
- Requires adding "ensure\_mandatory\_{scope}\_otp! to controllers;