### PR TITLE
Update Refreshable hook and helper methods to get/set values as strings again

### DIFF
--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -92,11 +92,11 @@ module DeviseOtpAuthenticatable
       end
 
       def otp_refresh_return_url_property
-        :refresh_return_url
+        "refresh_return_url"
       end
 
       def otp_refresh_property
-        :credentials_refreshed_at
+        "credentials_refreshed_at"
       end
 
       def otp_scoped_persistence_cookie

--- a/lib/devise_otp_authenticatable/hooks/refreshable.rb
+++ b/lib/devise_otp_authenticatable/hooks/refreshable.rb
@@ -1,5 +1,5 @@
 # After each sign in, update credentials refreshed at time
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
-  warden.session[:credentials_refreshed_at] = (Time.now + record.class.otp_credentials_refresh)
+  warden.session["credentials_refreshed_at"] = (Time.now + record.class.otp_credentials_refresh)
 end
 


### PR DESCRIPTION
@strzibny, I have identified a regression in the new Refreshable functionality, where the "credentials_refreshed_at" session value is not available to the needs_credentials_refresh? method, as Rack converts symbols to strings when storing session values. This causes the user to redirect continually to the otp/credentials/refresh page when trying to view the otp/token page since warden.session[:credentials_refreshed_at] remains nil.

I tried converting the symbols to strings where needed within the helper mehtods (e.g. needs_credentials_refresh?), but then the tests were failing. The reason for this appears to be that the test environment still get/sets symbols as symbols in the Rack session (as opposed to converting them to strings).

A simple solution is to utilize strings again for all get/set methods as before. This PR makes this change, and resolves the redirect issue mentioned above.

Leads:
- Rack Session https://www.rubydoc.info/gems/rack/1.6.0/Rack%2FSession%2FAbstract%2FSessionHash:[]=
- Rack Test Session: https://www.rubydoc.info/github/brynary/rack-test/Rack/Test/Session#env-instance_method