### PR TITLE
Switch test suite to default Rack Test

### DIFF
--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rotp", ">= 2.0.0"
 
   gem.add_development_dependency "capybara"
-  gem.add_development_dependency "cuprite"
   gem.add_development_dependency "minitest-reporters", ">= 0.5.0"
   gem.add_development_dependency "puma"
   gem.add_development_dependency "rdoc"

--- a/test/integration/persistence_test.rb
+++ b/test/integration/persistence_test.rb
@@ -51,13 +51,10 @@ class PersistenceTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    enable_chrome_headless_downloads(page, "/tmp/devise-otp")
+    click_link("Download recovery codes")
 
-    DownloadHelper.wait_for_download(count: 1) do
-      click_link("Download recovery codes")
-    end
-
-    assert_equal 1, DownloadHelper.downloads.size
+    assert current_path.match?(/recovery\.text/)
+    assert page.body.match?(user.next_otp_recovery_tokens.values.join("\n"))
   end
 
   test "trusted status should expire" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require "dummy/config/environment"
 require "orm/#{DEVISE_ORM}"
 require "rails/test_help"
 require "capybara/rails"
-require "capybara/cuprite"
 require "minitest/reporters"
 
 Minitest::Reporters.use!
@@ -15,26 +14,9 @@ Minitest::Reporters.use!
 
 # ActiveSupport::Deprecation.silenced = true
 
-# Use a module to not pollute the global namespace
-module CapybaraHelper
-  def self.register_driver(driver_name, args = [])
-    opts = {headless: true, js_errors: true, window_size: [1920, 1200], browser_options: {}}
-    args.each do |arg|
-      opts[:browser_options][arg] = nil
-    end
-
-    Capybara.register_driver(driver_name) do |app|
-      Capybara::Cuprite::Driver.new(app, opts)
-    end
-  end
-end
-
-# Register our own custom drivers
-CapybaraHelper.register_driver(:headless_chrome, %w[disable-gpu no-sandbox disable-dev-shm-usage])
-
 # Configure Capybara JS driver
-Capybara.current_driver = :headless_chrome
-Capybara.javascript_driver = :headless_chrome
+Capybara.current_driver = :rack_test
+Capybara.javascript_driver = :rack_test
 
 # Configure Capybara server
 Capybara.run_server = true
@@ -42,50 +24,6 @@ Capybara.server = :puma, {Silent: true}
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-
-  # What capybara calls a "page" in its DSL is actually a Capybara::Session
-  # and doesn't know about the *command* method that allows us to play with
-  # the Chrome API.
-  # See: https://rubydoc.info/github/jnicklas/capybara/master/Capybara/Session
-  #
-  # To enable downloads we need to do it on the browser's page object, so fetch it
-  # from this long method chain.
-  # See: https://github.com/rubycdp/ferrum/blob/master/lib/ferrum/page.rb
-  def enable_chrome_headless_downloads(session, directory)
-    page = session.driver.browser.page
-    page.command("Page.setDownloadBehavior", behavior: "allow", downloadPath: directory)
-  end
-end
-
-# From https://collectiveidea.com/blog/archives/2012/01/27/testing-file-downloads-with-capybara-and-chromedriver
-module DownloadHelper
-  extend self
-
-  TIMEOUT = 10
-
-  def downloads
-    Dir["/tmp/devise-otp/*"]
-  end
-
-  def wait_for_download(count: 1)
-    yield if block_given?
-
-    Timeout.timeout(TIMEOUT) do
-      sleep 0.2 until downloaded?(count)
-    end
-  end
-
-  def downloaded?(count)
-    !downloading? && downloads.size == count
-  end
-
-  def downloading?
-    downloads.grep(/\.crdownload$/).any?
-  end
-
-  def clear_downloads
-    FileUtils.rm_f(downloads)
-  end
 end
 
 require "devise-otp"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,14 +14,6 @@ Minitest::Reporters.use!
 
 # ActiveSupport::Deprecation.silenced = true
 
-# Configure Capybara JS driver
-Capybara.current_driver = :rack_test
-Capybara.javascript_driver = :rack_test
-
-# Configure Capybara server
-Capybara.run_server = true
-Capybara.server = :puma, {Silent: true}
-
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 end


### PR DESCRIPTION
The test suite utilizes the cuprite driver, which causes compatibility issues with the Warden redirect solution in PR #80 (produces a "Chrome data error" when querying the current_url). In addition, the current testing approach does not test the actual content of the recovery codes download (only that something was downloaded).

This PR switches the test suite to the default rack_test driver, which resolves the test failures in PR #80, adds tests for the actual content of the recovery codes download, and simplifies the codebase by removing the custom Capybara coniguration and DowloadHelper module.