### PR TITLE
CHANGED: Update supported Rails version to v7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Upgrade gemspec to support Rails v7.2
+
 ## 0.7.0
 
 Breaking changes:
@@ -57,4 +61,3 @@ Fixes:
 
 - mandatory otp fix by @cotcomsol in #68
 - remove success message by @strzibny in #69
-

--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split($/)
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "rails", ">= 6.1", "< 7.2"
+  gem.add_runtime_dependency "rails", ">= 6.1", "<= 7.2"
   gem.add_runtime_dependency "devise", ">= 4.8.0", "< 5.0"
   gem.add_runtime_dependency "rotp", ">= 2.0.0"
 

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -3,4 +3,9 @@ ActiveRecord::Base.logger = Logger.new(nil)
 
 migrations_path = File.expand_path("../../dummy/db/migrate/", __FILE__)
 
-ActiveRecord::MigrationContext.new(migrations_path, ActiveRecord::SchemaMigration).migrate
+if Rails.version.to_f >= 7.2
+  ActiveRecord::MigrationContext.new(migrations_path).migrate
+else
+  # To support order versions of Rails (pre v7.2)
+  ActiveRecord::MigrationContext.new(migrations_path, ActiveRecord::SchemaMigration).migrate
+end


### PR DESCRIPTION
**Summary:**

Update the support Rails version to v7.2.

When testing the gem with Rails v7.2 I didn't come across any issues and the functionality seemed to appear as intended. But that doesn't mean all use cases were covered.


**Screenshots:**

When attempting to upgrade a Rails v7.1 application to v7.2 while using the devise-otp gem.

<img width="567" alt="Screenshot 2024-08-10 at 12 11 01 AM" src="https://github.com/user-attachments/assets/358c7618-48a0-4854-93cd-58fd65316741">

**Additional follow-up issue**

- >`Remove deprecated support to passing `SchemaMigration` and `InternalMetadata` classes as arguments to
    `ActiveRecord::MigrationContext`.`

https://github.com/rails/rails/blob/c44d7ae6b1e0292a95a27b7a5573f4dec99e06f0/guides/source/7_2_release_notes.md?plain=1#L438
