### PR TITLE
Fix issue with scoped redirects for non-default resources

### DIFF
--- a/app/controllers/devise_otp/devise/otp_tokens_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_tokens_controller.rb
@@ -33,7 +33,7 @@ module DeviseOtp
         if resource.valid_otp_token?(params[:confirmation_code])
           resource.enable_otp!
           otp_set_flash_message :success, :successfully_updated
-          redirect_to action: :show
+          redirect_to otp_token_path_for(resource)
         else
           otp_set_flash_message :danger, :could_not_confirm
           render :edit
@@ -48,7 +48,7 @@ module DeviseOtp
           otp_set_flash_message :success, :successfully_disabled_otp
         end
 
-        redirect_to action: :show
+        redirect_to otp_token_path_for(resource)
       end
 
       #
@@ -59,7 +59,7 @@ module DeviseOtp
           otp_set_flash_message :success, :successfully_set_persistence
         end
 
-        redirect_to action: :show
+        redirect_to otp_token_path_for(resource)
       end
 
       #
@@ -70,7 +70,7 @@ module DeviseOtp
           otp_set_flash_message :success, :successfully_cleared_persistence
         end
 
-        redirect_to action: :show
+        redirect_to otp_token_path_for(resource)
       end
 
       #
@@ -81,7 +81,7 @@ module DeviseOtp
           otp_set_flash_message :notice, :successfully_reset_persistence
         end
 
-        redirect_to action: :show
+        redirect_to otp_token_path_for(resource)
       end
 
       def recovery
@@ -100,7 +100,7 @@ module DeviseOtp
           otp_set_flash_message :success, :successfully_reset_otp
         end
 
-        redirect_to action: :edit
+        redirect_to edit_otp_token_path_for(resource)
       end
 
       private

--- a/app/views/devise/otp_tokens/show.html.erb
+++ b/app/views/devise/otp_tokens/show.html.erb
@@ -7,7 +7,7 @@
   <%= render :partial => 'trusted_devices' if trusted_devices_enabled? %>
 
   <% unless otp_mandatory_on?(resource) %>
-    <%= button_to I18n.t('disable_link', :scope => 'devise.otp.otp_tokens'), @resource, :method => :delete, :data => { "turbo-method": "DELETE" } %>
+    <%= button_to I18n.t('disable_link', :scope => 'devise.otp.otp_tokens'), otp_token_path_for(resource), :method => :delete, :data => { "turbo-method": "DELETE" } %>
   <% end %>
 <% else %>
   <%= link_to I18n.t('enable_link', :scope => 'devise.otp.otp_tokens'), edit_otp_token_path_for(resource) %>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,6 +1,6 @@
 Dummy::Application.routes.draw do
-  devise_for :users
   devise_for :admins
+  devise_for :users
 
   resources :posts
   resources :admin_posts


### PR DESCRIPTION
@paweld-iRonin discovered an issue (#86) where the non-default resource was being redirected to the default resource's routes within the otp_tokens_controller. The underlying problem is that simply calling "redirect_to :show" in the otp_tokens_controller redirects to the default scope, rather than getting the proper scope for that resource.

This issue is a hold over from before, when we were only using one resource, and it was not reflected in tests, as the user scope is the default anyway. However, it can be reproduced by reversing the order of the "devise_for" additions for users and admins in the routes file of the test app.

This PR resolves the immediate issue, along with the attendant "Disable OTP" link issue. 