### PR TITLE
Add support for Rails 7.2, drop support for Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   rspec:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -16,17 +16,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Bundle
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run tests
         env:
           DEVISE_ORM: active_record
-        run: rake test
+        run: bundle exec rake test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.3'
+          - '3.2'
           - '3.1'
+          - 'head'
 
     steps:
       - name: Checkout

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem "capybara"
 gem "minitest-reporters", ">= 0.5.0"
 gem "puma"
+gem "rake"
 gem "rdoc"
 gem "shoulda"
 gem "sprockets-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,12 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in devise-otp.gemspec
 gemspec
+
+gem "capybara"
+gem "minitest-reporters", ">= 0.5.0"
+gem "puma"
+gem "rdoc"
+gem "shoulda"
+gem "sprockets-rails"
+gem "sqlite3", "~> 1.4"
+gem "standardrb"

--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split($/)
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "rails", ">= 6.1", "<= 7.2"
+  gem.add_runtime_dependency "rails", ">= 7.0", "< 8.0"
   gem.add_runtime_dependency "devise", ">= 4.8.0", "< 5.0"
   gem.add_runtime_dependency "rotp", ">= 2.0.0"
 

--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -14,16 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split($/)
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "rails", ">= 7.0", "< 8.0"
-  gem.add_runtime_dependency "devise", ">= 4.8.0", "< 5.0"
-  gem.add_runtime_dependency "rotp", ">= 2.0.0"
-
-  gem.add_development_dependency "capybara"
-  gem.add_development_dependency "minitest-reporters", ">= 0.5.0"
-  gem.add_development_dependency "puma"
-  gem.add_development_dependency "rdoc"
-  gem.add_development_dependency "shoulda"
-  gem.add_development_dependency "sprockets-rails"
-  gem.add_development_dependency "sqlite3", "~> 1.4"
-  gem.add_development_dependency "standardrb"
+  gem.add_dependency "rails", ">= 7.0", "< 8.0"
+  gem.add_dependency "devise", ">= 4.8.0", "< 5.0"
+  gem.add_dependency "rotp", ">= 2.0.0"
 end


### PR DESCRIPTION
Like [acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on/blob/master/acts-as-taggable-on.gemspec).

Note: the next Rails version is 8.0.

Thank you!