### PR TITLE
Fix Issue with Invalid Token Message | Simplify OTP Credentials Controller

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -26,17 +26,15 @@ module DeviseOtp
       # signs the resource in, if the OTP token is valid and the user has a valid challenge
       #
       def update
-        if @token.blank?
-          otp_set_flash_message(:alert, :token_blank)
-          redirect_to otp_credential_path_for(resource_name, challenge: @challenge, recovery: @recovery)
-        elsif resource.otp_challenge_valid? && resource.validate_otp_token(@token, @recovery)
+        if resource.otp_challenge_valid? && resource.validate_otp_token(@token, @recovery)
           sign_in(resource_name, resource)
 
           otp_set_trusted_device_for(resource) if params[:enable_persistence] == "true"
           otp_refresh_credentials_for(resource)
           respond_with resource, location: after_sign_in_path_for(resource)
         else
-          otp_set_flash_message :alert, :token_invalid, :now => true
+          kind = (@token.blank? ? :token_blank : :token_invalid)
+          otp_set_flash_message :alert, kind, :now => true
           render :show
         end
       end

--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -36,7 +36,7 @@ module DeviseOtp
           otp_refresh_credentials_for(resource)
           respond_with resource, location: after_sign_in_path_for(resource)
         else
-          otp_set_flash_message :alert, :token_invalid
+          otp_set_flash_message :alert, :token_invalid, :now => true
           render :show
         end
       end

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -16,7 +16,14 @@ module DeviseOtpAuthenticatable
         options[:resource_name] = resource_name
         options = devise_i18n_options(options) if respond_to?(:devise_i18n_options, true)
         message = I18n.t("#{options[:resource_name]}.#{kind}", **options)
-        flash[key] = message if message.present?
+
+        if message.present?
+          if options[:now]
+            flash.now[key] = message
+          else
+            flash[key] = message
+          end
+        end
       end
 
       def otp_t

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -8,7 +8,13 @@
 </head>
 <body>
 
-<%= yield %>
+  <% if flash[:alert].present? %>
+    <div id="alert">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+
+  <%= yield %>
 
 </body>
 </html>


### PR DESCRIPTION
Description: This PR fixes the Issue with Invalid Token message (#94), and simplifies the OTP Credentials controller to handle both blank and invalid tokens the same way.

Changes:
- Add support for displaying flash messages immediately via "flash.now" to otp_set_flash_message method (matching with the devise "set_flash_message" method)
- Update the OTP Credentials controller to handle both blank and failed tokens the same way (render "show" action rather than redirect), and to display the flash message immediately
- Add tests to confirm resolution

Resources:
- Devise's "set_flash_message" method ([link](https://github.com/heartcombo/devise/blob/72884642f5700439cc96ac560ee19a44af5a2d45/app/controllers/devise_controller.rb#L168))