### PR TITLE
Expand Flash Message Tests, Resolve Additional Issues, and simplify otp_set_flash_message

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -101,7 +101,7 @@ module DeviseOtp
       end
 
       def failed_refresh
-        otp_set_flash_message :alert, :invalid_refresh
+        otp_set_flash_message :alert, :invalid_refresh, :now => true
         render :refresh
       end
 

--- a/app/controllers/devise_otp/devise/otp_tokens_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_tokens_controller.rb
@@ -35,7 +35,7 @@ module DeviseOtp
           otp_set_flash_message :success, :successfully_updated
           redirect_to otp_token_path_for(resource)
         else
-          otp_set_flash_message :danger, :could_not_confirm
+          otp_set_flash_message :danger, :could_not_confirm, :now => true
           render :edit
         end
       end

--- a/lib/devise_otp_authenticatable/controllers/helpers.rb
+++ b/lib/devise_otp_authenticatable/controllers/helpers.rb
@@ -12,18 +12,8 @@ module DeviseOtpAuthenticatable
       #
       def otp_set_flash_message(key, kind, options = {})
         options[:scope] ||= "devise.otp.#{controller_name}"
-        options[:default] = Array(options[:default]).unshift(kind.to_sym)
-        options[:resource_name] = resource_name
-        options = devise_i18n_options(options) if respond_to?(:devise_i18n_options, true)
-        message = I18n.t("#{options[:resource_name]}.#{kind}", **options)
 
-        if message.present?
-          if options[:now]
-            flash.now[key] = message
-          else
-            flash[key] = message
-          end
-        end
+        set_flash_message(key, kind, options)
       end
 
       def otp_t

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -8,11 +8,11 @@
 </head>
 <body>
 
-  <% if flash[:alert].present? %>
-    <div id="alert">
-      <%= flash[:alert] %>
-    </div>
-  <% end %>
+  <div id="alerts">
+    <% flash.keys.each do |key| %>
+      <%= content_tag :p, flash[key], :id => key %>
+    <% end %>
+  </div>
 
   <%= yield %>
 

--- a/test/integration/disable_token_test.rb
+++ b/test/integration/disable_token_test.rb
@@ -23,6 +23,9 @@ class DisableTokenTest < ActionDispatch::IntegrationTest
     disable_otp
 
     assert page.has_content? "Disabled"
+    within "#alerts" do
+      assert page.has_content? 'Two-Factor Authentication has been disabled.'
+    end
 
     # logout
     sign_out

--- a/test/integration/enable_otp_form_test.rb
+++ b/test/integration/enable_otp_form_test.rb
@@ -45,6 +45,11 @@ class EnableOtpFormTest < ActionDispatch::IntegrationTest
     within "#alerts" do
       assert page.has_content? 'The Confirmation Code you entered did not match the QR code shown below.'
     end
+
+    visit "/"
+    within "#alerts" do
+      assert !page.has_content?('The Confirmation Code you entered did not match the QR code shown below.')
+    end
   end
 
   test "a user should not be able enable their OTP authentication with a blank confirmation code" do

--- a/test/integration/enable_otp_form_test.rb
+++ b/test/integration/enable_otp_form_test.rb
@@ -20,6 +20,10 @@ class EnableOtpFormTest < ActionDispatch::IntegrationTest
     assert_equal user_otp_token_path, current_path
     assert page.has_content?("Enabled")
 
+    within "#alerts" do
+      assert page.has_content? 'Your Two-Factor Authentication settings have been updated.'
+    end
+
     user.reload
     assert user.otp_enabled?
   end
@@ -37,6 +41,10 @@ class EnableOtpFormTest < ActionDispatch::IntegrationTest
 
     user.reload
     assert_not user.otp_enabled?
+
+    within "#alerts" do
+      assert page.has_content? 'The Confirmation Code you entered did not match the QR code shown below.'
+    end
   end
 
   test "a user should not be able enable their OTP authentication with a blank confirmation code" do
@@ -49,6 +57,10 @@ class EnableOtpFormTest < ActionDispatch::IntegrationTest
     click_button "Continue..."
 
     assert page.has_content?("To Enable Two-Factor Authentication")
+
+    within "#alerts" do
+      assert page.has_content? 'The Confirmation Code you entered did not match the QR code shown below.'
+    end
 
     user.reload
     assert_not user.otp_enabled?

--- a/test/integration/persistence_test.rb
+++ b/test/integration/persistence_test.rb
@@ -36,6 +36,9 @@ class PersistenceTest < ActionDispatch::IntegrationTest
 
     click_link("Trust this browser")
     assert_text "Your browser is trusted."
+    within "#alerts" do
+      assert page.has_content? 'Your device is now trusted.'
+    end
     sign_out
 
     sign_user_in

--- a/test/integration/refresh_test.rb
+++ b/test/integration/refresh_test.rb
@@ -60,6 +60,9 @@ class RefreshTest < ActionDispatch::IntegrationTest
     fill_in "user_refresh_password", with: "12345670"
     click_button "Continue..."
     assert_equal refresh_user_otp_credential_path, current_path
+    within "#alerts" do
+      assert page.has_content? 'Sorry, you provided the wrong credentials.'
+    end
   end
 
   test "user should be finally be able to access their settings, and just password is enough" do

--- a/test/integration/refresh_test.rb
+++ b/test/integration/refresh_test.rb
@@ -60,8 +60,14 @@ class RefreshTest < ActionDispatch::IntegrationTest
     fill_in "user_refresh_password", with: "12345670"
     click_button "Continue..."
     assert_equal refresh_user_otp_credential_path, current_path
+
     within "#alerts" do
       assert page.has_content? 'Sorry, you provided the wrong credentials.'
+    end
+
+    visit "/"
+    within "#alerts" do
+      assert !page.has_content?('Sorry, you provided the wrong credentials.')
     end
   end
 

--- a/test/integration/reset_token_test.rb
+++ b/test/integration/reset_token_test.rb
@@ -23,6 +23,9 @@ class ResetTokenTest < ActionDispatch::IntegrationTest
     reset_otp
 
     assert_equal "/users/otp/token/edit", current_path
+    within "#alerts" do
+      assert page.has_content? 'Your token secret has been reset. Please confirm your new token secret below.'
+    end
   end
 
   test "generates new token secrets" do


### PR DESCRIPTION
As a follow up to #95, I decided to work on adding flash tests inline with the existing controller tests. In doing so, I found two additional cases like issue #94, where the flash message was persisting incorrectly to the next view.

In addition, I realized that we can greatly simplify the otp_set_flash_message method via the existing Devise set_flash_message functionaliy. And with the flash test coverage in place, I think we can safely make this change.

This PR accomplishes the following:
- Expand test coverage for flash messages to all existing controller tests
- Resolve issue with "invalid_refresh" and "could_not_confirm" messages
- Simplify the "otp_set_flash_message" method

NOTE: This PR assumes PR #95, so please merge that PR first.