### PR TITLE
Update supported Ruby versions (2025/3/7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.4'
           - '3.3'
           - '3.2'
-          - '3.1'
           - 'head'
         rails:
           - rails_8.0

--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split($/)
   gem.require_paths = ["lib"]
 
+  gem.required_ruby_version = ">= 3.2.0"
+
   gem.add_dependency "rails", ">= 7.1"
   gem.add_dependency "devise", ">= 4.8.0", "< 5.0"
   gem.add_dependency "rotp", ">= 2.0.0"


### PR DESCRIPTION
- Add required_ruby_version to gemspc;
- Set minimum Ruby version set to 3.2 (3.1 EOL on 2025/3/31); 
- Add Ruby 3.4 to testing matrix (released 2024/12/25);