### PR TITLE
Release version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 ## Unreleased
 
-- Upgrade gemspec to support Rails v7.2
+## 1.0.0
+- Add support for Rails 8
+- Generate QR Codes as SVG
+- Fix Issue with Invalid Token Message
+- Simplify OTP Credentials Controller
+- Expand Flash Message Tests
+- Use Appraisal gem to against older Rails versions
+
+## 0.8.0
+- Add support for Rails 7.2 and drop support for Rails 6.1
+- Fix issue with scoped redirects for non-default resources
+- Add migration version numbers
+- Cleanup old docs
+
+## 0.7.1
+- Fix host and port for 3rd-party tests
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.0.1
+- Add support for Ruby 3.4
+- Set minimum Ruby version to 3.2
+- Set miminum Rails version to 7.1
+- Add MIT license type to gemspec
+- Correct Devise spelling error in README
+
 ## 1.0.0
 - Add support for Rails 8
 - Generate QR Codes as SVG

--- a/lib/devise-otp/version.rb
+++ b/lib/devise-otp/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module OTP
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
- Add missing entries for versions 0.7.1, 0.8.0, 1.0.0 to CHANGELOG
- Bump version to 1.0.1 for release, and add entry to CHANGELOG