### PR TITLE
Fix situation where some models have OTP enabled and others don't

### DIFF
--- a/lib/devise_otp_authenticatable/hooks/refreshable.rb
+++ b/lib/devise_otp_authenticatable/hooks/refreshable.rb
@@ -1,6 +1,6 @@
 # After each sign in, update credentials refreshed at time
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
-  if record.class.method_defined?(:otp_credentials_refresh)
+  if defined?(record.class.otp_credentials_refresh)
     warden.session(options[:scope])["credentials_refreshed_at"] = (Time.now + record.class.otp_credentials_refresh)
   end
 end

--- a/lib/devise_otp_authenticatable/hooks/refreshable.rb
+++ b/lib/devise_otp_authenticatable/hooks/refreshable.rb
@@ -1,5 +1,7 @@
 # After each sign in, update credentials refreshed at time
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
-  warden.session(options[:scope])["credentials_refreshed_at"] = (Time.now + record.class.otp_credentials_refresh)
+  if record.class.method_defined?(:otp_credentials_refresh)
+    warden.session(options[:scope])["credentials_refreshed_at"] = (Time.now + record.class.otp_credentials_refresh)
+  end
 end
 


### PR DESCRIPTION
We have two models in our app which use Devise. One uses OTP and the other should not have OTP enabled. Because `otp_credentials_refresh` is not defined on the model without OTP (it doesn't have `:otp_authenticatable`), this `after_set_user` block crashed. We've been using this modified version in production for some time and it seems to be working fine