### PR TITLE
Hotwire Compatibility Fixes

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -35,7 +35,7 @@ module DeviseOtp
         else
           kind = (@token.blank? ? :token_blank : :token_invalid)
           otp_set_flash_message :alert, kind, :now => true
-          render :show
+          render :show, status: :unprocessable_entity
         end
       end
 
@@ -102,7 +102,7 @@ module DeviseOtp
 
       def failed_refresh
         otp_set_flash_message :alert, :invalid_refresh, :now => true
-        render :refresh
+        render :refresh, status: :unprocessable_entity
       end
 
       def self.controller_path

--- a/app/controllers/devise_otp/devise/otp_tokens_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_tokens_controller.rb
@@ -36,7 +36,7 @@ module DeviseOtp
           redirect_to otp_token_path_for(resource)
         else
           otp_set_flash_message :danger, :could_not_confirm, :now => true
-          render :edit
+          render :edit, status: :unprocessable_entity
         end
       end
 

--- a/app/views/devise/otp_credentials/refresh.html.erb
+++ b/app/views/devise/otp_credentials/refresh.html.erb
@@ -1,7 +1,7 @@
 <h2><%= I18n.t('title', :scope => 'devise.otp.credentials_refresh') %></h2>
 <p><%= I18n.t('explain', :scope => 'devise.otp.credentials_refresh') %></p>
 
-<%= form_for(resource, :as => resource_name, :url => [:refresh, resource_name, :otp_credential], :html => { :method => :put, "data-turbo" => false }) do |f| %>
+<%= form_for(resource, :as => resource_name, :url => [:refresh, resource_name, :otp_credential], :html => { :method => :put }) do |f| %>
 
   <%= render "devise/shared/error_messages", resource: resource %>
 

--- a/app/views/devise/otp_credentials/show.html.erb
+++ b/app/views/devise/otp_credentials/show.html.erb
@@ -1,7 +1,7 @@
 <h2><%= I18n.t('title', :scope => 'devise.otp.submit_token') %></h2>
 <p><%= I18n.t('explain', :scope => 'devise.otp.submit_token') %></p>
 
-<%= form_for(resource, :as => resource_name, :url => [resource_name, :otp_credential], :html => { :method => :put, "data-turbo" => false }) do |f| %>
+<%= form_for(resource, :as => resource_name, :url => [resource_name, :otp_credential], :html => { :method => :put }) do |f| %>
 
   <%= hidden_field_tag :challenge, @challenge %>
   <%= hidden_field_tag :recovery, @recovery %>

--- a/test/integration/enable_otp_form_test.rb
+++ b/test/integration/enable_otp_form_test.rb
@@ -71,4 +71,16 @@ class EnableOtpFormTest < ActionDispatch::IntegrationTest
     assert_not user.otp_enabled?
   end
 
+  test "failed confirmation code should return a 422 'unprocessable entity' status" do
+    user = sign_user_in
+
+    visit edit_user_otp_token_path
+
+    fill_in "confirmation_code", with: "123456"
+
+    click_button "Continue..."
+
+    assert_equal 422, page.status_code
+  end
+
 end

--- a/test/integration/refresh_test.rb
+++ b/test/integration/refresh_test.rb
@@ -113,4 +113,20 @@ class RefreshTest < ActionDispatch::IntegrationTest
     assert_equal admin_otp_token_path, current_path
   end
 
+  test "failed credentials should return a 422 'unprocessable entity' status" do
+    sign_user_in
+    visit user_otp_token_path
+    assert_equal user_otp_token_path, current_path
+
+    sleep(2)
+
+    visit user_otp_token_path
+    assert_equal refresh_user_otp_credential_path, current_path
+
+    fill_in "user_refresh_password", with: "12345670"
+    click_button "Continue..."
+
+    assert_equal 422, page.status_code
+  end
+
 end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -57,6 +57,16 @@ class SignInTest < ActionDispatch::IntegrationTest
     assert page.has_content? "You need to type in the token you generated with your device."
   end
 
+  test "failed authentication should return a 422 'unprocessable entity' status" do
+    enable_otp_and_sign_in
+    assert_equal user_otp_credential_path, current_path
+
+    fill_in "token", with: "123456"
+    click_button "Submit Token"
+
+    assert_equal 422, page.status_code
+  end
+
   test "successful token authentication" do
     user = enable_otp_and_sign_in
 


### PR DESCRIPTION
 - Update failed OTP sign in, failed OTP confirmation, and failed OTP credential refresh to return 422 "unprocessable entity" status
 - Remove "data-turbo => false" from OTP credentials and refresh credentials forms (no longer needed)
 - Add tests to confirm resolution