### PR TITLE
Use native ROTP drift functionality for validating time based OTP tokens

### DIFF
--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -116,10 +116,8 @@ module Devise::Models
     private
 
     def validate_otp_token_with_drift(token)
-      # should be centered around saved drift
-      (-self.class.otp_drift_window..self.class.otp_drift_window).any? { |drift|
-        time_based_otp.verify(token, at: Time.now.ago(30 * drift))
-      }
+      verified_token_time = time_based_otp.verify token, drift_behind: self.class.otp_drift_window * 30
+      verified_token_time.present?
     end
 
     def generate_otp_persistence_seed

--- a/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
+++ b/lib/devise_otp_authenticatable/models/otp_authenticatable.rb
@@ -116,7 +116,11 @@ module Devise::Models
     private
 
     def validate_otp_token_with_drift(token)
-      verified_token_time = time_based_otp.verify token, drift_behind: self.class.otp_drift_window * 30
+      verified_token_time = time_based_otp.verify(token,
+        drift_behind: self.class.otp_drift_window * 30,
+        drift_ahead: self.class.otp_drift_window * 30,
+      )
+
       verified_token_time.present?
     end
 

--- a/test/integration/otp_drift_test.rb
+++ b/test/integration/otp_drift_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "integration_tests_helper"
+
+class OtpDriftTest < ActionDispatch::IntegrationTest
+  def teardown
+    Capybara.reset_sessions!
+    Timecop.return
+  end
+
+  test "should allow OTP token usage up within the OTP drift window" do
+    user = enable_otp_and_sign_in
+
+    copied_token = ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
+
+    Timecop.freeze(Time.now + 90)
+
+    fill_in "token", with: copied_token
+    click_button "Submit Token"
+
+    assert_equal root_path, current_path
+  end
+
+  test "should not allow OTP token usage beyond the OTP drift window" do
+    user = enable_otp_and_sign_in
+
+    copied_token = ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
+
+    Timecop.freeze(Time.now + 120)
+
+    fill_in "token", with: copied_token
+    click_button "Submit Token"
+
+    assert_not_equal root_path, current_path
+  end
+
+end


### PR DESCRIPTION
The ROTP gem includes built-in functionality for handling TOTP drift via the "drift_behind" option. This offers a much simpler solution vs. iterating over a possible range of valid times for a time based OTP token on our end.

For context, the "drift" functionality referenced here gives users additional time when copy/pasting their OTP tokens into the browser (up to the interval specified by the user via otp_authentication_time_drift). This helps to minimize situations where an user copies a time based OTP token near the end of its valid window (e.g. less than 5 seconds or so), and then pastes it after the valid window has passed.

This Pull Request addresses the first half of issue #28 . Thanks to @eimermusic for the suggestion.