### PR TITLE
Switch to Timecop gem for testing time based functionality

### DIFF
--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "devise", ">= 4.8.0", "< 5.0"
   gem.add_dependency "rotp", ">= 2.0.0"
   gem.add_dependency "rqrcode", "~> 2.0"
+
+  gem.add_development_dependency "timecop", "~> 0.9.10"
 end

--- a/test/integration/persistence_test.rb
+++ b/test/integration/persistence_test.rb
@@ -10,6 +10,7 @@ class PersistenceTest < ActionDispatch::IntegrationTest
   def teardown
     User.otp_trust_persistence = @old_persistence
     Capybara.reset_sessions!
+    Timecop.return
   end
 
   test "a user should be requested the otp challenge every log in" do
@@ -72,9 +73,9 @@ class PersistenceTest < ActionDispatch::IntegrationTest
     assert_text "Your browser is trusted."
     sign_out
 
-    sleep User.otp_trust_persistence.to_i + 1
-    sign_user_in
+    Timecop.travel(Time.now + 30.days)
 
+    sign_user_in
     assert_equal user_otp_credential_path, current_path
   end
 end

--- a/test/integration/refresh_test.rb
+++ b/test/integration/refresh_test.rb
@@ -2,16 +2,9 @@ require "test_helper"
 require "integration_tests_helper"
 
 class RefreshTest < ActionDispatch::IntegrationTest
-  def setup
-    @old_refresh = User.otp_credentials_refresh
-    User.otp_credentials_refresh = 1.second
-    Admin.otp_credentials_refresh = 1.second
-  end
-
   def teardown
-    User.otp_credentials_refresh = @old_refresh
-    Admin.otp_credentials_refresh = @old_refresh
     Capybara.reset_sessions!
+    Timecop.return
   end
 
   test "a user that just signed in should be able to access their OTP settings without refreshing" do
@@ -26,7 +19,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    sleep(2)
+    Timecop.travel(Time.now + 15.minutes)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -37,7 +30,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    sleep(2)
+    Timecop.travel(Time.now + 15.minutes)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -52,7 +45,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    sleep(2)
+    Timecop.travel(Time.now + 15.minutes)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -74,7 +67,8 @@ class RefreshTest < ActionDispatch::IntegrationTest
   test "user should be finally be able to access their settings, and just password is enough" do
     user = enable_otp_and_sign_in_with_otp
 
-    sleep(2)
+    Timecop.travel(Time.now + 15.minutes)
+
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
 
@@ -102,7 +96,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     click_button "Submit Token"
     assert_equal "/", current_path
 
-    sleep(2)
+    Timecop.travel(Time.now + 15.minutes)
 
     visit admin_otp_token_path
     assert_equal refresh_admin_otp_credential_path, current_path
@@ -118,7 +112,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    sleep(2)
+    Timecop.travel(Time.now + 15.minutes)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path

--- a/test/models/otp_authenticatable_test.rb
+++ b/test/models/otp_authenticatable_test.rb
@@ -6,6 +6,10 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     new_user
   end
 
+  def teardown
+    Timecop.return
+  end
+
   test "new users do not have a secret set" do
     user = User.first
 
@@ -95,7 +99,8 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     u.populate_otp_secrets!
     u.enable_otp!
     challenge = u.generate_otp_challenge!(1.second)
-    sleep(2)
+
+    Timecop.travel(Time.now + 2)
 
     w = User.find_valid_otp_challenge(challenge)
     assert_nil w
@@ -106,7 +111,7 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     u.populate_otp_secrets!
     u.enable_otp!
     challenge = u.generate_otp_challenge!(1.second)
-    sleep(2)
+    Timecop.travel(Time.now + 2)
     assert_equal false, u.otp_challenge_valid?
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "dummy/config/environment"
 require "rails/test_help"
 require "capybara/rails"
 require "minitest/reporters"
+require "timecop"
 
 Minitest::Reporters.use!
 


### PR DESCRIPTION
Switch to Timecop gem for testing time based functionality:
- Avoids the need for overriding default time values 
- Improves test speed