### PR TITLE
Update README to reflect otp_drift_window usage (i.e. steps, not minutes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The install generator adds some options to the end of your Devise config file (`
 
 * `config.otp_mandatory`: OTP is mandatory, users are going to be asked to enroll the next time they sign in, before they can successfully complete the session establishment.
 * `config.otp_authentication_timeout`: How long the user has to authenticate with their token. (defaults to `3.minutes`)
-* `config.otp_drift_window`: A window which provides allowance for drift between a user's token device clock (and therefore their OTP tokens) and the authentication server's clock. Expressed in minutes centered at the current time. (default: `3`)
+* `config.otp_drift_window`: A window which provides allowance for drift between a user's token device clock (and therefore their OTP tokens) and the authentication server's clock. Expressed in "steps" of 30 second increments. (default: `3`)
 * `config.otp_credentials_refresh`: Users that have logged in longer than this time ago, are going to be asked their password (and an OTP challenge, if enabled) before they can see or change their otp informations. (defaults to `15.minutes`)
 * `config.otp_recovery_tokens`: Whether the users are given a list of one-time recovery tokens, for emergency access (default: `10`, set to `false` to disable)
 * `config.otp_trust_persistence`: The user is allowed to set his browser as "trusted", no more OTP challenges will be asked for that browser, for a limited time. (default: `1.month`, set to false to disable setting the browser as trusted)


### PR DESCRIPTION
While working on #121 , I discovered that the otp_drift_window actually defines "steps," not minutes. These steps translate to 30 second increments, as demonstrated here in the existing master branch:

https://github.com/wmlele/devise-otp/blob/72d083065f5696a3af9bd4510cdbf52a3462e1df/lib/devise_otp_authenticatable/models/otp_authenticatable.rb#L118-L123

NOTE: The RFC for OTP's recommendation is indeed to make the time steps 30 seconds each (cf. https://www.rfc-editor.org/rfc/rfc6238#section-5.2). So the implementation is correct - the README just needs to be updated.

This Pull Requests updates the README, and adds an explanatory comment to the OTP drift window test.