### PR TITLE
Remove timecop in favour of rails time helpers

### DIFF
--- a/devise-otp.gemspec
+++ b/devise-otp.gemspec
@@ -21,6 +21,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency "devise", ">= 4.8.0", "< 5.0"
   gem.add_dependency "rotp", ">= 2.0.0"
   gem.add_dependency "rqrcode", "~> 2.0"
-
-  gem.add_development_dependency "timecop", "~> 0.9.10"
 end

--- a/test/integration/enable_otp_form_test.rb
+++ b/test/integration/enable_otp_form_test.rb
@@ -72,7 +72,7 @@ class EnableOtpFormTest < ActionDispatch::IntegrationTest
   end
 
   test "failed confirmation code should return a 422 'unprocessable entity' status" do
-    user = sign_user_in
+    sign_user_in
 
     visit edit_user_otp_token_path
 

--- a/test/integration/persistence_test.rb
+++ b/test/integration/persistence_test.rb
@@ -10,7 +10,7 @@ class PersistenceTest < ActionDispatch::IntegrationTest
   def teardown
     User.otp_trust_persistence = @old_persistence
     Capybara.reset_sessions!
-    Timecop.return
+    travel_back
   end
 
   test "a user should be requested the otp challenge every log in" do
@@ -73,7 +73,7 @@ class PersistenceTest < ActionDispatch::IntegrationTest
     assert_text "Your browser is trusted."
     sign_out
 
-    Timecop.travel(Time.now + 30.days)
+    travel_to(30.days.from_now)
 
     sign_user_in
     assert_equal user_otp_credential_path, current_path

--- a/test/integration/refresh_test.rb
+++ b/test/integration/refresh_test.rb
@@ -4,7 +4,7 @@ require "integration_tests_helper"
 class RefreshTest < ActionDispatch::IntegrationTest
   def teardown
     Capybara.reset_sessions!
-    Timecop.return
+    travel_back
   end
 
   test "a user that just signed in should be able to access their OTP settings without refreshing" do
@@ -19,7 +19,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    Timecop.travel(Time.now + 15.minutes)
+    travel_to(15.minutes.from_now + 1.second)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -30,7 +30,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    Timecop.travel(Time.now + 15.minutes)
+    travel_to(15.minutes.from_now + 1.second)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -45,7 +45,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    Timecop.travel(Time.now + 15.minutes)
+    travel_to(15.minutes.from_now + 1.second)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -65,9 +65,9 @@ class RefreshTest < ActionDispatch::IntegrationTest
   end
 
   test "user should be finally be able to access their settings, and just password is enough" do
-    user = enable_otp_and_sign_in_with_otp
+    enable_otp_and_sign_in_with_otp
 
-    Timecop.travel(Time.now + 15.minutes)
+    travel_to(15.minutes.from_now + 1.second)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path
@@ -96,7 +96,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     click_button "Submit Token"
     assert_equal "/", current_path
 
-    Timecop.travel(Time.now + 15.minutes)
+    travel_to(15.minutes.from_now + 1.second)
 
     visit admin_otp_token_path
     assert_equal refresh_admin_otp_credential_path, current_path
@@ -112,7 +112,7 @@ class RefreshTest < ActionDispatch::IntegrationTest
     visit user_otp_token_path
     assert_equal user_otp_token_path, current_path
 
-    Timecop.travel(Time.now + 15.minutes)
+    travel_to(15.minutes.from_now + 1.second)
 
     visit user_otp_token_path
     assert_equal refresh_user_otp_credential_path, current_path

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -4,7 +4,7 @@ require "integration_tests_helper"
 class SignInTest < ActionDispatch::IntegrationTest
   def teardown
     Capybara.reset_sessions!
-    Timecop.return
+    travel_back
   end
 
   test "a new user should be able to sign in without using their token" do
@@ -19,7 +19,7 @@ class SignInTest < ActionDispatch::IntegrationTest
   end
 
   test "a new user, just signed in, should be able to see and click the 'Enable Two-Factor Authentication' link" do
-    user = sign_user_in
+    sign_user_in
 
     visit user_otp_token_path
     assert page.has_content?("Disabled")
@@ -80,7 +80,7 @@ class SignInTest < ActionDispatch::IntegrationTest
   test "should fail if the the challenge times out" do
     user = enable_otp_and_sign_in
 
-    Timecop.travel(Time.now + 3.minutes)
+    travel_to(3.minutes.from_now + 1.second)
 
     fill_in "token", with: ROTP::TOTP.new(user.otp_auth_secret).at(Time.now)
     click_button "Submit Token"

--- a/test/models/otp_authenticatable_test.rb
+++ b/test/models/otp_authenticatable_test.rb
@@ -7,7 +7,7 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
   end
 
   def teardown
-    Timecop.return
+    travel_back
   end
 
   test "new users do not have a secret set" do
@@ -100,7 +100,7 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     u.enable_otp!
     challenge = u.generate_otp_challenge!(1.second)
 
-    Timecop.travel(Time.now + 2)
+    travel_to(2.seconds.from_now)
 
     w = User.find_valid_otp_challenge(challenge)
     assert_nil w
@@ -110,8 +110,8 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     u = User.first
     u.populate_otp_secrets!
     u.enable_otp!
-    challenge = u.generate_otp_challenge!(1.second)
-    Timecop.travel(Time.now + 2)
+    u.generate_otp_challenge!(1.second)
+    travel_to(2.seconds.from_now)
     assert_equal false, u.otp_challenge_valid?
   end
 
@@ -142,11 +142,11 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     secret = u.otp_auth_secret
     token = ROTP::TOTP.new(secret).at(Time.now)
 
-    Timecop.freeze(Time.now + 90)
+    travel_to(90.seconds.from_now)
     assert_equal true, u.valid_otp_token?(token)
 
-    Timecop.return
-    Timecop.freeze(Time.now - 90)
+    travel_back
+    travel_to(90.seconds.ago)
     assert_equal true, u.valid_otp_token?(token)
   end
 
@@ -158,11 +158,11 @@ class OtpAuthenticatableTest < ActiveSupport::TestCase
     secret = u.otp_auth_secret
     token = ROTP::TOTP.new(secret).at(Time.now)
 
-    Timecop.freeze(Time.now + 120)
+    travel_to(120.seconds.from_now)
     assert_equal false, u.valid_otp_token?(token)
 
-    Timecop.return
-    Timecop.freeze(Time.now - 120)
+    travel_back
+    travel_to(120.seconds.ago)
     assert_equal false, u.valid_otp_token?(token)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,6 @@ require "dummy/config/environment"
 require "rails/test_help"
 require "capybara/rails"
 require "minitest/reporters"
-require "timecop"
 
 Minitest::Reporters.use!
 


### PR DESCRIPTION
One less dependency to bundle for development. Also fixed a handful of warning here around local variables not being used