### PR TITLE
Fix bug in updated "Remember Me" strategy (rebased)

### DIFF
--- a/app/controllers/devise_otp/devise/otp_credentials_controller.rb
+++ b/app/controllers/devise_otp/devise/otp_credentials_controller.rb
@@ -111,6 +111,8 @@ module DeviseOtp
       def skip_challenge_if_trusted_browser
         if is_otp_trusted_browser_for?(resource)
           sign_in(resource_name, resource)
+
+          remember_me(resource) if resource.devise_modules.include?(:rememberable) and @remember_me
           otp_refresh_credentials_for(resource)
           redirect_to after_sign_in_path_for(resource)
         end

--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -104,6 +104,30 @@ class RememberableTest < ActionDispatch::IntegrationTest
     assert page.driver.browser.last_request.cookies['remember_rememberable_user_token']
   end
 
+  test "rememberable users with browser persistence enabled are still remembered when signing in" do
+    visit new_rememberable_user_session_path
+
+    fill_in "rememberable_user_email", with: "rememberable-user@email.invalid"
+    fill_in "rememberable_user_password", with: "12345678"
+    check "Remember me"
+    click_button("Log in")
+
+    fill_in "token", with: ROTP::TOTP.new(@rememberable_user.otp_auth_secret).at(Time.now)
+    click_button("Submit Token")
+
+    visit rememberable_user_otp_token_path
+    click_button "Trust this browser"
+    click_button("Sign Out")
+
+    visit new_rememberable_user_session_path
+    fill_in "rememberable_user_email", with: "rememberable-user@email.invalid"
+    fill_in "rememberable_user_password", with: "12345678"
+    check "Remember me"
+    click_button("Log in")
+
+    assert page.driver.browser.last_request.cookies['remember_rememberable_user_token']
+  end
+
   test "normal users without rememberable strategy are not affected" do
     create_full_user
     visit new_user_session_path


### PR DESCRIPTION
PR #138 updated the "Remember Me" functionality to delegate setting the rememberable cookie to the OTP Credentials controller (previously, Rememberable was not working). However, the OTP Credentials controller was not updated to account for situations where the user has trusted their current browser, thereby skipping the OTP Credentials form.

This Pull Request updates the OTP Credentials controller to set the "Remember Me" value within the skip_challenge_if_trusted_browser "before_action" (in addition to the normal update action) for situations where the user is bypassing the OTP Credentials form due to browser persistence.